### PR TITLE
Add support for strikethrough `InlineContent`

### DIFF
--- a/Sources/DocCArchive/Schema_0_1/InlineContent.swift
+++ b/Sources/DocCArchive/Schema_0_1/InlineContent.swift
@@ -18,18 +18,20 @@ extension DocCArchive.DocCSchema_0_1 {
                    overridingTitleInlineContent : [ InlineContent ]?)
     case image    (identifier: String)
     case emphasis ([ InlineContent ])
+    case strikethrough   ([ InlineContent ])
     case strong   ([ InlineContent ])
     case codeVoice(code: String)
     
     public var description: String {
       switch self {
-        case .text     (let s)       :  return "“\(s)”"
+        case .text          (let s)       :  return "“\(s)”"
         case .reference(let id, let isActive, _, _):
           return "\(id)\(isActive ? "" : "-inactive")"
-        case .image    (let id)      : return "<img \(id)>"
-        case .emphasis (let content) : return "*\(content)*"
-        case .strong   (let content) : return "**\(content)**"
-        case .codeVoice(let code)    : return "`\(code)`"
+        case .image         (let id)      : return "<img \(id)>"
+        case .emphasis      (let content) : return "*\(content)*"
+        case .strikethrough (let content) : return "~~\(content)~~"
+        case .strong        (let content) : return "**\(content)**"
+        case .codeVoice     (let code)    : return "`\(code)`"
       }
     }
 
@@ -84,24 +86,27 @@ extension DocCArchive.DocCSchema_0_1 {
       
       switch self {
         case .text(let text):
-          try container.encode("text"      , forKey: .type)
-          try container.encode(text        , forKey: .text)
+          try container.encode("text"         , forKey: .type)
+          try container.encode(text           , forKey: .text)
         case .codeVoice(let code):
-          try container.encode("codeVoice" , forKey: .type)
-          try container.encode(code        , forKey: .code)
+          try container.encode("codeVoice"    , forKey: .type)
+          try container.encode(code           , forKey: .code)
         case .image(let identifier):
-          try container.encode("image"     , forKey: .type)
-          try container.encode(identifier  , forKey: .identifier)
+          try container.encode("image"        , forKey: .type)
+          try container.encode(identifier     , forKey: .identifier)
         case .emphasis(let content):
-          try container.encode("emphasis"  , forKey: .type)
-          try container.encode(content     , forKey: .inlineContent)
+          try container.encode("emphasis"     , forKey: .type)
+          try container.encode(content        , forKey: .inlineContent)
+        case .strikethrough(let content):
+          try container.encode("strikethrough", forKey: .type)
+          try container.encode(content        , forKey: .inlineContent)
         case .strong(let content):
-          try container.encode("strong"    , forKey: .type)
-          try container.encode(content     , forKey: .inlineContent)
+          try container.encode("strong"       , forKey: .type)
+          try container.encode(content        , forKey: .inlineContent)
         case .reference(let identifier, let isActive, let ot, let otc):
-          try container.encode("reference" , forKey: .type)
-          try container.encode(identifier  , forKey: .identifier)
-          try container.encode(isActive    , forKey: .isActive)
+          try container.encode("reference"    , forKey: .type)
+          try container.encode(identifier     , forKey: .identifier)
+          try container.encode(isActive       , forKey: .isActive)
           if let v = ot  { try container.encode(v , forKey: .overridingTitle) }
           if let v = otc {
             try container.encode(v, forKey: .overridingTitleInlineContent)


### PR DESCRIPTION
⚠️ This change is a breaking change which will force a change in `docc2html` ⚠️ 

When using `docc2html` on my documentation, I noticed that I was generating content with a `strikethrough` `InlineContent` type. You can see the documentation that generated this here: https://github.com/DavidBrunow/brunow.org/blob/main/Sources/BrunowOrg/Documentation.docc/Posts/2023/10-21-here-be-dragons-snapshot-testing-edition.md?plain=1#L141

And you can see the generated DocC JSON here (the JSON is all on one line, so it is difficult to see from this link alone): https://github.com/DavidBrunow/brunow.org/blob/main/docs/data/documentation/brunow/10-21-here-be-dragons-snapshot-testing-edition.json#L1

Here is what that strikethrough JSON looks like, in case you don't want to copy and paste the contents of that link into a text editor:

```json
{
    "type": "paragraph",
    "inlineContent": [
        {
            "inlineContent": [
                {
                    "type": "text",
                    "text": "I have absolutely no insight into why I’m seeing the behavior I’m seeing on"
                },
                {
                    "text": " ",
                    "type": "text"
                },
                {
                    "type": "text",
                    "text": "Xcode Cloud but I can make some guesses based upon what I do know. I know that"
                },
                {
                    "type": "text",
                    "text": " "
                },
                {
                    "text": "Apple is going through a processor transition where their CPUs have changed from",
                    "type": "text"
                },
                {
                    "type": "text",
                    "text": " "
                },
                {
                    "text": "being manufactured by Intel to being manufactured by Apple. Along with this CPU",
                    "type": "text"
                },
                {
                    "text": " ",
                    "type": "text"
                },
                {
                    "text": "change comes GPU changes as well since Apple is creating their own GPUs.",
                    "type": "text"
                }
            ],
            "type": "strikethrough"
        }
    ]
}
```