### PR TITLE
Add `section` as a case for `TopicReference.Kind`

### DIFF
--- a/Sources/DocCArchive/Schema_0_1/References/TopicReference.swift
+++ b/Sources/DocCArchive/Schema_0_1/References/TopicReference.swift
@@ -14,7 +14,7 @@ extension DocCArchive.DocCSchema_0_1 {
     
     // Looks like Kind & Role are the same? - I think they scope differently
     public enum Kind: String, Codable {
-      case symbol, article, overview, project
+      case symbol, article, overview, project, section
     }
     
     // Samples:


### PR DESCRIPTION
⚠️ This pull request breaks docc2html. This pull request implements the required changes there: https://github.com/DoccZz/docc2html/pull/25 ⚠️ 

When using this to generate my documentation, I found an additional case for `TopicReference`. This is the documentation that generates it: https://github.com/DavidBrunow/brunow.org/blob/main/Sources/BrunowOrg/Documentation.docc/Posts/2023/10-21-here-be-dragons-snapshot-testing-edition.md?plain=1#L555

And this is the generated JSON: https://github.com/DavidBrunow/brunow.org/blob/main/docs/data/documentation/brunow/10-21-here-be-dragons-snapshot-testing-edition.json

Since that all renders on a single line, it is tough to parse without another tool. Here is what the relevant JSON blob looks like:

``` json
...
"doc://Brunow/documentation/Brunow/08-30-snapshot-testing-with-xcode-cloud#Creating-Something-Reusable":{
  "url":"\/documentation\/brunow\/08-30-snapshot-testing-with-xcode-cloud#Creating-Something-Reusable",
  "title":"Creating Something Reusable",
  "kind":"section",
  "type":"topic",
  "identifier":"doc:\/\/Brunow\/documentation\/Brunow\/08-30-snapshot-testing-with-xcode-cloud#Creating-Something-Reusable",
  "abstract":[]
}
...
```