### PR TITLE
Support `@3x` images

### DIFF
--- a/Sources/DocCArchive/Schema_0_1/References/ImageReference.swift
+++ b/Sources/DocCArchive/Schema_0_1/References/ImageReference.swift
@@ -23,7 +23,7 @@ extension DocCArchive.DocCSchema_0_1 {
     public struct Variant: Equatable, Codable, CustomStringConvertible {
       
       public enum Trait: String, Codable {
-        case nonRetina = "1x", retina = "2x", light, dark
+        case nonRetina = "1x", retina = "2x", threeX = "3x", light, dark
       }
       
       public var url    : String // it's a path, not a URL


### PR DESCRIPTION
DocC supports `@3x` images in addition to `@2x` and the default of `@1x`. 

You can see this in the JSON output here: https://github.com/DavidBrunow/brunow.org/blob/main/docs/data/documentation/brunow/11-30-follow-up-snapshot-testing-xcode-cloud-sonoma.json

Here is the relevant bit of JSON:

```json
...
        "misrenderedSwiftUIList.png": {
            "variants": [
                {
                    "url": "\/images\/misrenderedSwiftUIList@3x.png",
                    "traits": [
                        "3x",
                        "light"
                    ]
                }
            ],
            "alt": "Screenshot of a user interface which was not rendered properly in snapshot tests.",
            "identifier": "misrenderedSwiftUIList.png",
            "type": "image"
        },
...
``` 

I don't love the name of the case, "retina" and "nonRetina" are much nicer, but I haven't come up with anything better.

FYI I also tried using `@4x` with an image and DocC **does not** accept that.



