### PR TITLE
Update `ImageReference` to allow the `alt` property to be optional

### DIFF
--- a/Sources/DocCArchive/Schema_0_1/References/ImageReference.swift
+++ b/Sources/DocCArchive/Schema_0_1/References/ImageReference.swift
@@ -50,7 +50,7 @@ extension DocCArchive.DocCSchema_0_1 {
     }
     
     public var identifier : String
-    public var alt        : String
+    public var alt        : String?
     public var variants   : [ Variant ]
 
     public func bestVariant(for traits: Set<Variant.Trait>) -> Variant? {
@@ -73,8 +73,8 @@ extension DocCArchive.DocCSchema_0_1 {
 
     public var description: String {
       var ms = "<ImageRef[\(identifier)]: "
-      if !alt.isEmpty { ms += " “\(alt)”" }
-      
+      if let alt = alt, !alt.isEmpty { ms += " “\(alt)”" }
+
       if      variants.isEmpty    { ms += " no-variants"                 }
       else if variants.count == 1 { ms += " \(variants[0])"              }
       else                        { ms += " #variants=\(variants.count)" }


### PR DESCRIPTION
⚠️ This change will break docc2html, this pull request fixes it: https://github.com/DoccZz/docc2html/pull/27 ⚠️ 

In some cases, the `alt` property in an `ImageReference` is `null`. I think this may be a bug in DocC, since I've intentionally provided alt text, but even if it is a bug it seems like it should be handled.

Here is the documentation that generated a `null` value for the alt text: https://github.com/DavidBrunow/brunow.org/blob/main/Sources/BrunowOrg/Documentation.docc/Posts/2023/10-21-here-be-dragons-snapshot-testing-edition.md?plain=1#L8

And here is the generated JSON: https://github.com/DavidBrunow/brunow.org/blob/main/docs/data/documentation/brunow/10-21-here-be-dragons-snapshot-testing-edition.json

And the relevant part of that JSON:
```
...
"misrenderedSwiftUIList.png":{
  "alt":null,
  "identifier":"misrenderedSwiftUIList.png",
  "type":"image",
  "variants": [
    {
      "url": "\/images\/misrenderedSwiftUIList@3x.png",
      "traits": [
        "3x",
        "light"
      ]
    }
  ]
}
...
```